### PR TITLE
Mystery Constants named & moved to C.java

### DIFF
--- a/Odyssey/src/main/java/org/usfirst/frc841/Odyssey/C.java
+++ b/Odyssey/src/main/java/org/usfirst/frc841/Odyssey/C.java
@@ -21,6 +21,10 @@ public class C {
 	public static final double centervalue = 140;
 	public static final double tolerance = 10;
 	public static final int currentlimit = 40;
+
+	// Turn to Target constants (used in drive)
+	public static final double turnTargDeadband = 3; //double from >0 to ?? 
+	public static final double turnTargRate = 0.3; //double from 0 to 1, sets drive strength in bang-bang control mode
 	
 	// AUTONOMOUS CONSTANTS
 	public static final double autoDrivingDistance = .5; // In time, is seconds driving from the starting point to one of the nodes of movement in the autonomous mode.

--- a/Odyssey/src/main/java/org/usfirst/frc841/Odyssey/subsystems/DriveTrain.java
+++ b/Odyssey/src/main/java/org/usfirst/frc841/Odyssey/subsystems/DriveTrain.java
@@ -410,19 +410,21 @@ public class DriveTrain extends Subsystem {
     /**
      * This method takes in the camera value and directs the drive to turn in the direction to center it.
      * It uses the same method as the signal lights
-     * TODO: Research whether we need 2nd NetworkTableInstance here??
+     * 
      */
     public void TurnToTarget() {
 
         SmartDashboard.putNumber("LimelightXPTT", this.x);
         SmartDashboard.putNumber("LimelightVPTT", this.v);
 
+//Should we fetch the Limelight Area value and try to use that to adjust the deadband dynamically? 
+
         if (this.v >= 1){
-            if (this.x > 3){
-                SetLeftRight(.3,.3); //TODO: is this the correct direction?
+            if (this.x > C.turnTargDeadband){
+                SetLeftRight(C.turnTargRate,C.turnTargRate); 
             }
-            else if (this.x <= -3){
-                SetLeftRight(-.3,-.3); //TODO: is this the correct direction?
+            else if (this.x <= C.turnTargDeadband){
+                SetLeftRight(-C.turnTargRate,-C.turnTargRate); 
             }
             else {
                 //if pointed at target, do nothing


### PR DESCRIPTION
This set of changes takes Mystery Constants out of the vision turn to target code, and replaces them with Constant values listed in C.java file.

Bang-Bang style controls are still implemented, but at least they're with named vars now.